### PR TITLE
fix: bug for CustomAPIUIResponseWriter func

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -233,7 +233,12 @@ func (s *Server) CustomAPIUIResponseWriter(cssURL, jsURL, version writer.StringG
 	if !ok {
 		return
 	}
-	w, ok := wi.(*writer.HTMLResponseWriter)
+	gw, ok := wi.(*writer.GzipWriter)
+	if !ok {
+		return
+	}
+
+	w, ok := gw.ResponseWriter.(*writer.HTMLResponseWriter)
 	if !ok {
 		return
 	}


### PR DESCRIPTION
html ResponseWriters  is assigned a GzipWiter and is not a HTMLResponseWriter. asserts that it will fail anyway and must first be converted to a GzipWiter