### PR TITLE
Updates for pagination

### DIFF
--- a/pkg/types/server_types.go
+++ b/pkg/types/server_types.go
@@ -238,6 +238,8 @@ type APIObject struct {
 type APIObjectList struct {
 	Revision string
 	Continue string
+	Pages    int
+	Count    int
 	Objects  []APIObject
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -15,6 +15,8 @@ type Collection struct {
 	Pagination   *Pagination       `json:"pagination,omitempty"`
 	Revision     string            `json:"revision,omitempty"`
 	Continue     string            `json:"continue,omitempty"`
+	Pages        int               `json:"pages,omitempty"`
+	Count        int               `json:"count,omitempty"`
 }
 
 type GenericCollection struct {

--- a/pkg/writer/encoding.go
+++ b/pkg/writer/encoding.go
@@ -133,6 +133,8 @@ func newCollection(apiOp *types.APIRequest, list types.APIObjectList) *types.Gen
 			Actions:  map[string]string{},
 			Continue: list.Continue,
 			Revision: list.Revision,
+			Pages:    list.Pages,
+			Count:    list.Count,
 		},
 	}
 


### PR DESCRIPTION
### Remove Pagination type 

The Pagination struct was copied over from norman in the initial commit.
It is not used by norman, steve, or any other consumer of apiserver.
Remove it to avoid confusion with the new pagination API in steve.

### Add Pages and Count to list-type resources

Paginated collections will include the total number of pages and
resources so that clients know how many to expect

https://github.com/rancher/rancher/issues/38427
Needed for https://github.com/rancher/steve/pull/63