### PR TITLE
Add check for nil schema ID before recording it

### DIFF
--- a/pkg/fakes/dummy_writer.go
+++ b/pkg/fakes/dummy_writer.go
@@ -1,0 +1,30 @@
+package fakes
+
+import "net/http"
+
+// All other writers will attempt additional unnecessary logic
+// Implements http.responseWriter and io.Writer
+type DummyWriter struct {
+	header map[string][]string
+	buffer []byte
+}
+
+func NewDummyWriter() *DummyWriter {
+	return &DummyWriter{map[string][]string{}, []byte{}}
+}
+
+func (d *DummyWriter) Header() http.Header {
+	return d.header
+}
+
+func (d *DummyWriter) Buffer() []byte {
+	return d.buffer
+}
+
+func (d *DummyWriter) Write(p []byte) (n int, err error) {
+	d.buffer = append(d.buffer, p...)
+	return 0, nil
+}
+
+func (d *DummyWriter) WriteHeader(int) {
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -151,7 +151,8 @@ func (s *Server) handle(apiOp *types.APIRequest, parser parse.Parser) {
 	} else if code > http.StatusOK {
 		apiOp.Response.WriteHeader(code)
 	}
-	metrics.RecordResponseTime(apiOp.Schema.ID, apiOp.Method, strconv.Itoa(code), float64(time.Since(requestStart).Milliseconds()))
+
+	metrics.RecordResponseTime(apiOp.Type, apiOp.Method, strconv.Itoa(code), float64(time.Since(requestStart).Milliseconds()))
 }
 
 func (s *Server) handleOp(apiOp *types.APIRequest) (int, interface{}, error) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/rancher/apiserver/pkg/fakes"
+	"github.com/rancher/apiserver/pkg/parse"
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type ServerSuite struct {
+	suite.Suite
+}
+
+func TestServer(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(ServerSuite))
+}
+
+func (p *ServerSuite) TestServer_handle() {
+	response := fakes.NewDummyWriter()
+	request, _ := http.NewRequest("GET", "http://example.com", nil)
+
+	apiRequest := new(types.APIRequest)
+	apiRequest.Request = request
+	apiRequest.Response = response
+
+	type fields struct {
+		ResponseWriters map[string]types.ResponseWriter
+		Schemas         *types.APISchemas
+		AccessControl   types.AccessControl
+		Parser          parse.Parser
+		URLParser       parse.URLParser
+	}
+	type args struct {
+		apiOp  *types.APIRequest
+		parser parse.Parser
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			name: "empty Schema doesn't cause panic",
+			fields: fields{
+				ResponseWriters: map[string]types.ResponseWriter{},
+				Schemas:         new(types.APISchemas),
+				AccessControl:   &SchemaBasedAccess{},
+				Parser:          parse.Parse,
+				URLParser:       parse.MuxURLParser,
+			},
+			args: args{
+				apiOp:  apiRequest,
+				parser: func(apiOp *types.APIRequest, urlParser parse.URLParser) error { return nil },
+			},
+		},
+	}
+	for _, tt := range tests {
+		p.Run(tt.name, func() {
+			s := &Server{
+				ResponseWriters: tt.fields.ResponseWriters,
+				Schemas:         tt.fields.Schemas,
+				AccessControl:   tt.fields.AccessControl,
+				Parser:          tt.fields.Parser,
+				URLParser:       tt.fields.URLParser,
+			}
+			s.handle(tt.args.apiOp, tt.args.parser)
+		})
+	}
+}


### PR DESCRIPTION
Addresses https://github.com/rancher/rancher/issues/40296

When viewing an API that a user does not have permission to access in debug mode, there would be a panic. That was because the `apiOp.Schema` would be nil, so trying to access the `ID` member caused a nil pointer dereference.

Before the attempt to view the API would fail (as expected) and that continues to be the case. But now if the `Schema` is unset it defaults to the value `unknown` and we no longer get a panic in the debug logs. I'm not sure if there is a better default value, so please let me know if there is a preferred alternative.