### PR TITLE
Bumps rancher/wrangler to it's tagged v2 version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ There are a few main types to be aware of.
 
 [APISchema](https://pkg.go.dev/github.com/rancher/apiserver/pkg/types#APISchema)
 adds additional functionality on top of [wrangler's Schema
-type](https://pkg.go.dev/github.com/rancher/wrangler/pkg/schemas#Schema).
+type](https://pkg.go.dev/github.com/rancher/wrangler/v2/pkg/schemas#Schema).
 In addition to metadata about the type of object it represents, it also defines
 CRUD handlers, formatting transformations, and the backing Store.
 
@@ -139,7 +139,7 @@ this kind of internal schema.
 could also be used directly if desired:
 
 ```go
-import "github.com/rancher/wrangler/pkg/schemas"
+import "github.com/rancher/wrangler/v2/pkg/schemas"
 s.Schemas.MustAddSchema(types.APISchema{
     Schema: &schemas.Schema{
         ID: "duck",

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/prometheus/client_golang v1.16.0
-	github.com/rancher/wrangler v1.1.1-0.20230831050635-df1bd5aae9df
+	github.com/rancher/wrangler/v2 v2.0.2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	k8s.io/apimachinery v0.27.4

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI
 github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
-github.com/rancher/wrangler v1.1.1-0.20230831050635-df1bd5aae9df h1:WJ+aaUICHPX8HeLmHE9JL/RFHhilMfcJlqmhgpc7gJU=
-github.com/rancher/wrangler v1.1.1-0.20230831050635-df1bd5aae9df/go.mod h1:4T80p+rLh2OLbjCjdExIjRHKNBgK9NUAd7eIU/gRPKk=
+github.com/rancher/wrangler/v2 v2.0.2 h1:EWaWaD5Gnh8gGcLzglf/zktyuaiTi6e95c0T2RivVi8=
+github.com/rancher/wrangler/v2 v2.0.2/go.mod h1:p0YJmpbUbEQ1CE1GIbhwa9gCXeBJOBsQ6F6+Nf3LeLo=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/pkg/apierror/error.go
+++ b/pkg/apierror/error.go
@@ -3,7 +3,7 @@ package apierror
 import (
 	"fmt"
 
-	"github.com/rancher/wrangler/pkg/schemas/validation"
+	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
 )
 
 type APIError struct {

--- a/pkg/builtin/schema.go
+++ b/pkg/builtin/schema.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/rancher/apiserver/pkg/store/schema"
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/schemas"
-	"github.com/rancher/wrangler/pkg/slice"
+	"github.com/rancher/wrangler/v2/pkg/schemas"
+	"github.com/rancher/wrangler/v2/pkg/slice"
 )
 
 var (

--- a/pkg/handlers/create.go
+++ b/pkg/handlers/create.go
@@ -4,7 +4,7 @@ import (
 	"github.com/rancher/apiserver/pkg/apierror"
 	"github.com/rancher/apiserver/pkg/parse"
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/schemas/validation"
+	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
 )
 
 func CreateHandler(apiOp *types.APIRequest) (types.APIObject, error) {

--- a/pkg/handlers/delete.go
+++ b/pkg/handlers/delete.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"github.com/rancher/apiserver/pkg/apierror"
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/schemas/validation"
+	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
 )
 
 func DeleteHandler(request *types.APIRequest) (types.APIObject, error) {

--- a/pkg/handlers/error.go
+++ b/pkg/handlers/error.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/rancher/apiserver/pkg/apierror"
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/schemas/validation"
+	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/handlers/list.go
+++ b/pkg/handlers/list.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"github.com/rancher/apiserver/pkg/apierror"
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/schemas/validation"
+	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
 )
 
 func ByIDHandler(request *types.APIRequest) (types.APIObject, error) {

--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/apiserver/pkg/apierror"
 	"github.com/rancher/apiserver/pkg/parse"
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/schemas/validation"
+	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
 )
 
 func UpdateHandler(apiOp *types.APIRequest) (types.APIObject, error) {

--- a/pkg/parse/read_input.go
+++ b/pkg/parse/read_input.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/rancher/apiserver/pkg/apierror"
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/data/convert"
-	"github.com/rancher/wrangler/pkg/schemas/validation"
+	"github.com/rancher/wrangler/v2/pkg/data/convert"
+	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 

--- a/pkg/parse/validate.go
+++ b/pkg/parse/validate.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/rancher/apiserver/pkg/apierror"
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/schemas/validation"
+	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
 )
 
 var (

--- a/pkg/server/access.go
+++ b/pkg/server/access.go
@@ -7,8 +7,8 @@ import (
 	"github.com/rancher/apiserver/pkg/apierror"
 
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/schemas/validation"
-	"github.com/rancher/wrangler/pkg/slice"
+	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
+	"github.com/rancher/wrangler/v2/pkg/slice"
 )
 
 type SchemaBasedAccess struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rancher/apiserver/pkg/subscribe"
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/apiserver/pkg/writer"
-	"github.com/rancher/wrangler/pkg/schemas/validation"
+	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
 )
 
 type RequestHandler interface {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/rancher/apiserver/pkg/parse"
 	"github.com/rancher/apiserver/pkg/types"
 	"github.com/rancher/apiserver/pkg/writer"
-	"github.com/rancher/wrangler/pkg/schemas"
-	"github.com/rancher/wrangler/pkg/schemas/validation"
+	"github.com/rancher/wrangler/v2/pkg/schemas"
+	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )

--- a/pkg/server/validate.go
+++ b/pkg/server/validate.go
@@ -9,8 +9,8 @@ import (
 	"github.com/rancher/apiserver/pkg/apierror"
 	"github.com/rancher/apiserver/pkg/parse"
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/schemas"
-	"github.com/rancher/wrangler/pkg/schemas/validation"
+	"github.com/rancher/wrangler/v2/pkg/schemas"
+	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
 )
 
 const (

--- a/pkg/store/apiroot/apiroot.go
+++ b/pkg/store/apiroot/apiroot.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/rancher/apiserver/pkg/store/empty"
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/schemas"
+	"github.com/rancher/wrangler/v2/pkg/schemas"
 )
 
 func Register(apiSchemas *types.APISchemas, versions []string, roots ...string) {

--- a/pkg/store/empty/empty_store.go
+++ b/pkg/store/empty/empty_store.go
@@ -2,7 +2,7 @@ package empty
 
 import (
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/schemas/validation"
+	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
 )
 
 type Store struct {

--- a/pkg/store/schema/schema_store.go
+++ b/pkg/store/schema/schema_store.go
@@ -4,8 +4,8 @@ import (
 	"github.com/rancher/apiserver/pkg/apierror"
 	"github.com/rancher/apiserver/pkg/store/empty"
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/schemas/definition"
-	"github.com/rancher/wrangler/pkg/schemas/validation"
+	"github.com/rancher/wrangler/v2/pkg/schemas/definition"
+	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
 )
 
 type Store struct {

--- a/pkg/subscribe/handler.go
+++ b/pkg/subscribe/handler.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/schemas/validation"
+	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/subscribe/watcher_test.go
+++ b/pkg/subscribe/watcher_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/schemas"
+	"github.com/rancher/wrangler/v2/pkg/schemas"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/types/schemas.go
+++ b/pkg/types/schemas.go
@@ -3,7 +3,7 @@ package types
 import (
 	"strings"
 
-	"github.com/rancher/wrangler/pkg/schemas"
+	"github.com/rancher/wrangler/v2/pkg/schemas"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/types/server_types.go
+++ b/pkg/types/server_types.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/rancher/wrangler/pkg/data"
-	"github.com/rancher/wrangler/pkg/data/convert"
-	"github.com/rancher/wrangler/pkg/schemas/validation"
+	"github.com/rancher/wrangler/v2/pkg/data"
+	"github.com/rancher/wrangler/v2/pkg/data/convert"
+	"github.com/rancher/wrangler/v2/pkg/schemas/validation"
 	meta2 "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -3,7 +3,7 @@ package types
 import (
 	"net/http"
 
-	"github.com/rancher/wrangler/pkg/schemas"
+	"github.com/rancher/wrangler/v2/pkg/schemas"
 )
 
 type Collection struct {

--- a/pkg/urlbuilder/url.go
+++ b/pkg/urlbuilder/url.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/rancher/apiserver/pkg/types"
-	"github.com/rancher/wrangler/pkg/name"
+	"github.com/rancher/wrangler/v2/pkg/name"
 )
 
 const (


### PR DESCRIPTION
# Issue: https://github.com/rancher/rancher/issues/43618
The previous wrangler commit included all of the v2 changes. Except for the import path changes.