### PR TITLE
Run go test on CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,53 @@
 ---
 kind: pipeline
+name: amd64
+type: docker
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build
+  pull: default
+  image: rancher/dapper:v0.6.0
+  commands:
+  - dapper ci
+  privileged: true
+  volumes:
+  - name: socket
+    path: /var/run/docker.sock
+
+volumes:
+- name: socket
+  host:
+    path: /var/run/docker.sock
+---
+kind: pipeline
+name: arm64
+type: docker
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  pull: default
+  image: rancher/dapper:v0.6.0
+  commands:
+  - dapper ci
+  privileged: true
+  volumes:
+  - name: socket
+    path: /var/run/docker.sock
+
+volumes:
+- name: socket
+  host:
+    path: /var/run/docker.sock
+---
+kind: pipeline
 name: fossa
 
 steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-.idea
+/.idea
+/.dapper

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,0 +1,18 @@
+FROM registry.suse.com/bci/golang:1.20
+
+ARG DAPPER_HOST_ARCH
+ENV ARCH $DAPPER_HOST_ARCH
+ARG CACHEBUST=1
+RUN zypper -n up && \
+    zypper -n in git vim curl wget
+RUN rm -rf /go/src /go/pkg
+
+# prevents `detected dubious ownership in repository` git error due to uid/gid not matching when using bind mounts
+RUN git config -f /etc/gitconfig --add safe.directory /go/src/github.com/rancher/apiserver
+
+ENV DAPPER_SOURCE /go/src/github.com/rancher/apiserver/
+ENV DAPPER_RUN_ARGS "-v apiserver-pkg:/go/pkg -v apiserver-cache:/root/.cache/go-build"
+WORKDIR ${DAPPER_SOURCE}
+
+ENTRYPOINT ["./scripts/entry"]
+CMD ["ci"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+TARGETS := $(shell ls scripts)
+
+.dapper:
+	@echo Downloading dapper
+	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
+	@@chmod +x .dapper.tmp
+	@./.dapper.tmp -v
+	@mv .dapper.tmp .dapper
+
+$(TARGETS): .dapper
+	./.dapper $@
+
+.DEFAULT_GOAL := ci
+
+.PHONY: $(TARGETS)

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)
+
+./test

--- a/scripts/entry
+++ b/scripts/entry
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+mkdir -p bin dist
+if [ -e ./scripts/$1 ]; then
+    ./scripts/"$@"
+else
+    exec "$@"
+fi
+
+chown -R $DAPPER_UID:$DAPPER_GID .

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)/..
+
+echo Running tests
+go test -race -cover ./...


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/44445

We do have a few tests in apiserver and those are not being run in the CI.

This PR adds 2 drone pipeline, one for amd64 and one for arm64, which simply runs `go test ./...`.

The next thing would be to add golangci-lint. golangci-lint currently fails for a few reasons: ignored errors, unused variables, variables overwritten, etc. I'm not knowledgeable enough to fix those while being confident that I don't introduce regressions.