### PR TITLE
Run go test with GH actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+
+    - run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+test:
+	go test -race -cover ./...
+
+.PHONY: test


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/44445

This PR adds a GH action to run `go test`. I'm adding `make test` as a command to run to try and be consistent with the other repos (webhook, rancher, cli, etc) but without introducing dapper since it appears we also want to move away from it.