### PR TITLE
[FIX]server has URLParser, but not use it

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -40,6 +40,9 @@ type Parser func(apiOp *types.APIRequest, urlParser URLParser) error
 
 func Parse(apiOp *types.APIRequest, urlParser URLParser) error {
 	var err error
+	if urlParser == nil {
+		urlParser = MuxURLParser
+	}
 
 	if apiOp.Request == nil {
 		apiOp.Request, err = http.NewRequest("GET", "/", nil)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -106,7 +106,7 @@ func (s *Server) handle(apiOp *types.APIRequest, parser parse.Parser) {
 		apiOp.Schemas = s.Schemas
 	}
 
-	if err := parser(apiOp, parse.MuxURLParser); err != nil {
+	if err := parser(apiOp, s.URLParser); err != nil {
 		// ensure defaults set so writer is assigned
 		s.setDefaults(apiOp)
 		apiOp.WriteError(err)


### PR DESCRIPTION
# question
server can set URLParser, but not use it, always use the default one  
# test  
1. use DefaultAPIServer  

@ibuildthecloud @MbolotSuse @JonCrowther 
@tomleb 

