### PR TITLE
[v0.1] Create release on tag push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name : Checkout repository
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+    - name: Create release on Github
+      run: |
+        gh --repo "${{ github.repository }}" release create ${{ github.ref_name }} --verify-tag --generate-notes
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/46902

I only ported the GHA workflow, renovate only needs to exist on `main` and VERSION.md is fine to just be on `main` too for now.