### PR TITLE
Add ResourceType and Namespace to event

### DIFF
--- a/pkg/subscribe/watcher.go
+++ b/pkg/subscribe/watcher.go
@@ -95,6 +95,8 @@ func (s *WatchSession) stream(ctx context.Context, sub Subscribe, result chan<- 
 			if event.Error == nil {
 				event.ID = sub.ID
 				event.Selector = sub.Selector
+				event.ResourceType = sub.ResourceType
+				event.Namespace = sub.Namespace
 				select {
 				case result <- event:
 				default:


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/40773

The `resourceType` and `namespace` field were missing in events from the watch from Steve. We'll need this for the SQL cache work.

This allows the UI to disambiguate between different watches.