### PR TITLE
Add notification subscription mode

### DIFF
--- a/pkg/subscribe/handler.go
+++ b/pkg/subscribe/handler.go
@@ -23,7 +23,7 @@ const (
 	SubscriptionModeDefault SubscriptionMode = ""
 	// SubscriptionModeNotification tells the subscription to return a notification event
 	// whenever an event comes in. The consumer is expected to then make another list request
-	// request to get the latest data.
+	// to get the latest data.
 	SubscriptionModeNotification SubscriptionMode = "resource.changes"
 )
 

--- a/pkg/subscribe/handler.go
+++ b/pkg/subscribe/handler.go
@@ -15,17 +15,30 @@ var upgrader = websocket.Upgrader{
 	EnableCompression: true,
 }
 
+type SubscriptionMode string
+
+const (
+	// SubscriptionModeDefault tells the subscription to return the events
+	// as they come in with the object embedded inside
+	SubscriptionModeDefault SubscriptionMode = ""
+	// SubscriptionModeNotification tells the subscription to return a notification event
+	// whenever an event comes in. The consumer is expected to then make another list request
+	// request to get the latest data.
+	SubscriptionModeNotification SubscriptionMode = "resource.changes"
+)
+
 type Subscribe struct {
-	Stop            bool   `json:"stop,omitempty"`
-	ResourceType    string `json:"resourceType,omitempty"`
-	ResourceVersion string `json:"resourceVersion,omitempty"`
-	Namespace       string `json:"namespace,omitempty"`
-	ID              string `json:"id,omitempty"`
-	Selector        string `json:"selector,omitempty"`
+	Mode            SubscriptionMode `json:"mode,omitempty"`
+	Stop            bool             `json:"stop,omitempty"`
+	ResourceType    string           `json:"resourceType,omitempty"`
+	ResourceVersion string           `json:"resourceVersion,omitempty"`
+	Namespace       string           `json:"namespace,omitempty"`
+	ID              string           `json:"id,omitempty"`
+	Selector        string           `json:"selector,omitempty"`
 }
 
 func (s *Subscribe) key() string {
-	return s.ResourceType + "/" + s.Namespace + "/" + s.ID + "/" + s.Selector
+	return s.ResourceType + "/" + s.Namespace + "/" + s.ID + "/" + s.Selector + "/" + string(s.Mode)
 }
 
 func NewHandler(getter SchemasGetter, serverVersion string) types.RequestListHandler {

--- a/pkg/subscribe/watcher.go
+++ b/pkg/subscribe/watcher.go
@@ -32,6 +32,7 @@ func (s *WatchSession) stop(sub Subscribe, resp chan<- types.APIEvent) {
 			Namespace:    sub.Namespace,
 			ID:           sub.ID,
 			Selector:     sub.Selector,
+			Mode:         string(sub.Mode),
 		}
 	}
 	delete(s.watchers, sub.key())
@@ -86,30 +87,43 @@ func (s *WatchSession) stream(ctx context.Context, sub Subscribe, result chan<- 
 		Namespace:    sub.Namespace,
 		ID:           sub.ID,
 		Selector:     sub.Selector,
+		Mode:         string(sub.Mode),
 	}
 
 	if c == nil {
 		<-s.apiOp.Context().Done()
 	} else {
 		for event := range c {
-			if event.Error == nil {
-				event.ID = sub.ID
-				event.Selector = sub.Selector
-				event.ResourceType = sub.ResourceType
-				event.Namespace = sub.Namespace
-				select {
-				case result <- event:
-				default:
-					// handle slow consumer
-					go func() {
-						for range c {
-							// continue to drain until close
-						}
-					}()
-					return nil
-				}
-			} else {
+			if event.Error != nil {
 				sendErr(result, event.Error, sub)
+			}
+
+			var ev types.APIEvent
+			switch sub.Mode {
+			case SubscriptionModeDefault:
+				ev = event
+			case SubscriptionModeNotification:
+				ev = types.APIEvent{
+					Name: string(SubscriptionModeNotification),
+				}
+			}
+
+			ev.ID = sub.ID
+			ev.Selector = sub.Selector
+			ev.ResourceType = sub.ResourceType
+			ev.Namespace = sub.Namespace
+			ev.Mode = string(sub.Mode)
+
+			select {
+			case result <- ev:
+			default:
+				// handle slow consumer
+				go func() {
+					for range c {
+						// continue to drain until close
+					}
+				}()
+				return nil
 			}
 		}
 	}
@@ -181,6 +195,7 @@ func sendErr(resp chan<- types.APIEvent, err error, sub Subscribe) {
 		Namespace:    sub.Namespace,
 		ID:           sub.ID,
 		Selector:     sub.Selector,
+		Mode:         string(sub.Mode),
 		Error:        err,
 	}
 }

--- a/pkg/subscribe/watcher.go
+++ b/pkg/subscribe/watcher.go
@@ -96,6 +96,7 @@ func (s *WatchSession) stream(ctx context.Context, sub Subscribe, result chan<- 
 		for event := range c {
 			if event.Error != nil {
 				sendErr(result, event.Error, sub)
+				continue
 			}
 
 			var ev types.APIEvent

--- a/pkg/subscribe/watcher_test.go
+++ b/pkg/subscribe/watcher_test.go
@@ -34,6 +34,7 @@ func Test_stream(t *testing.T) {
 				{
 					Name:         "resource.create",
 					ResourceType: "watchable-resource",
+					Data:         data,
 				},
 			},
 		},
@@ -54,6 +55,7 @@ func Test_stream(t *testing.T) {
 					Name:         "resource.create",
 					ResourceType: "watchable-resource",
 					Namespace:    "test-ns",
+					Data:         data,
 				},
 			},
 		},
@@ -74,6 +76,7 @@ func Test_stream(t *testing.T) {
 					Name:         "resource.create",
 					ResourceType: "watchable-resource",
 					Selector:     "foo=bar",
+					Data:         data,
 				},
 			},
 		},
@@ -94,6 +97,7 @@ func Test_stream(t *testing.T) {
 					Name:         "resource.create",
 					ResourceType: "watchable-resource",
 					ID:           "test-resource",
+					Data:         data,
 				},
 			},
 		},
@@ -120,6 +124,26 @@ func Test_stream(t *testing.T) {
 			},
 			hasAccess: false,
 			wantError: true,
+		},
+		{
+			name: "notification",
+			sub: Subscribe{
+				ResourceType: "watchable-resource",
+				Mode:         SubscriptionModeNotification,
+			},
+			hasAccess: true,
+			wantEvents: []types.APIEvent{
+				{
+					Name:         "resource.start",
+					ResourceType: "watchable-resource",
+					Mode:         string(SubscriptionModeNotification),
+				},
+				{
+					Name:         "resource.changes",
+					ResourceType: "watchable-resource",
+					Mode:         string(SubscriptionModeNotification),
+				},
+			},
 		},
 	}
 	ws := WatchSession{
@@ -168,6 +192,8 @@ func Test_stream(t *testing.T) {
 	}
 }
 
+const data = "data"
+
 type mockStore struct{}
 
 func (m *mockStore) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
@@ -195,6 +221,7 @@ func (m *mockStore) Watch(apiOp *types.APIRequest, schema *types.APISchema, w ty
 	go func() {
 		c <- types.APIEvent{
 			Name: "resource.create",
+			Data: data,
 		}
 		close(c)
 	}()

--- a/pkg/types/server_types.go
+++ b/pkg/types/server_types.go
@@ -232,6 +232,7 @@ type APIEvent struct {
 	ID           string    `json:"id,omitempty"`
 	Selector     string    `json:"selector,omitempty"`
 	Revision     string    `json:"revision,omitempty"`
+	Mode         string    `json:"mode,omitempty"`
 	Object       APIObject `json:"-"`
 	Error        error     `json:"-"`
 	// Data is the output format of the object


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/40773

Depends on https://github.com/rancher/apiserver/pull/160

For the new SQL cache work, we want a new way of watching resources where the UI only gets a notification when something changed and the UI is then expected to re-list. This means the notification itself doesn't contain any event-specific data.

Here's an example session between the UI and Steve:

```
UI:     {"resourceType":"configmaps","mode":"resource.changes"}
Server: {"name":"resource.start","resourceType":"configmaps","mode":"resource.changes","data":{"type":"subscribe","links":{}}}
Server: {"name":"resource.changes","resourceType":"configmaps","mode":"resource.changes","data":{"type":"subscribe","links":{}}}
```

Added some tests to ensure the notification doesn't contain any data.

A future PR will come to add some form of "debouncing" for these notifications.