### PR TITLE
Add debouncer for events in notification mode 

### DIFF
--- a/pkg/subscribe/debouncer.go
+++ b/pkg/subscribe/debouncer.go
@@ -27,10 +27,10 @@ type debouncer struct {
 	outCh chan types.APIEvent
 }
 
-func newDebouncer(debouceRate time.Duration, eventsCh chan types.APIEvent) *debouncer {
+func newDebouncer(debounceRate time.Duration, eventsCh chan types.APIEvent) *debouncer {
 	d := &debouncer{
-		debounceRate: debouceRate,
-		timer:        time.NewTimer(debouceRate),
+		debounceRate: debounceRate,
+		timer:        time.NewTimer(debounceRate),
 		inCh:         eventsCh,
 		outCh:        make(chan types.APIEvent),
 	}

--- a/pkg/subscribe/debouncer.go
+++ b/pkg/subscribe/debouncer.go
@@ -1,0 +1,87 @@
+package subscribe
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rancher/apiserver/pkg/types"
+)
+
+type DebouncerState int
+
+const (
+	// The first notification is always sent right away, no need to wait
+	FirstNotification DebouncerState = iota
+	TimerStarted
+	TimerStopped
+)
+
+type debouncer struct {
+	lock sync.Mutex
+
+	timer        *time.Timer
+	debounceRate time.Duration
+
+	inCh  chan types.APIEvent
+	outCh chan types.APIEvent
+}
+
+func newDebouncer(debouceRate time.Duration, eventsCh chan types.APIEvent) *debouncer {
+	d := &debouncer{
+		debounceRate: debouceRate,
+		timer:        time.NewTimer(debouceRate),
+		inCh:         eventsCh,
+		outCh:        make(chan types.APIEvent),
+	}
+	d.timer.Stop()
+	return d
+}
+
+func (d *debouncer) Run(ctx context.Context) {
+	state := FirstNotification
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			break loop
+		case ev, ok := <-d.inCh:
+			if ev.Error != nil {
+				ev.Name = string(SubscriptionModeNotification)
+				d.outCh <- ev
+				break loop
+			}
+
+			if !ok {
+				break loop
+			}
+
+			d.lock.Lock()
+			switch state {
+			case FirstNotification:
+				d.outCh <- types.APIEvent{
+					Name: string(SubscriptionModeNotification),
+				}
+				state = TimerStopped
+			case TimerStopped:
+				state = TimerStarted
+				d.timer.Reset(d.debounceRate)
+			}
+			d.lock.Unlock()
+		case <-d.timer.C:
+			d.lock.Lock()
+			d.outCh <- types.APIEvent{
+				Name: string(SubscriptionModeNotification),
+			}
+			d.timer.Stop()
+			state = TimerStopped
+			d.lock.Unlock()
+		}
+	}
+
+	close(d.outCh)
+}
+
+func (d *debouncer) NotificationsChan() chan types.APIEvent {
+	return d.outCh
+}

--- a/pkg/subscribe/debouncer_test.go
+++ b/pkg/subscribe/debouncer_test.go
@@ -1,0 +1,44 @@
+package subscribe
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDebouncer(t *testing.T) {
+	ctx := context.Background()
+
+	debounceRate := 100 * time.Millisecond
+
+	// 5 events, but we'll expect only two
+	count := 5
+	eventsCh := make(chan types.APIEvent, count)
+	for range count {
+		eventsCh <- types.APIEvent{}
+	}
+	time.AfterFunc(200*time.Millisecond, func() {
+		close(eventsCh)
+	})
+
+	deb := newDebouncer(debounceRate, eventsCh)
+	go deb.Run(ctx)
+
+	expectedEvents := []types.APIEvent{
+		{
+			Name: string(SubscriptionModeNotification),
+		},
+		{
+			Name: string(SubscriptionModeNotification),
+		},
+	}
+
+	var gotEvents []types.APIEvent
+	for ev := range deb.NotificationsChan() {
+		gotEvents = append(gotEvents, ev)
+	}
+	assert.Equal(t, expectedEvents, gotEvents)
+}

--- a/pkg/subscribe/handler.go
+++ b/pkg/subscribe/handler.go
@@ -2,6 +2,7 @@ package subscribe
 
 import (
 	"encoding/json"
+	"strconv"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -35,10 +36,12 @@ type Subscribe struct {
 	Namespace       string           `json:"namespace,omitempty"`
 	ID              string           `json:"id,omitempty"`
 	Selector        string           `json:"selector,omitempty"`
+	// DebounceMs will debounce event when Mode is SubscriptionModeNotification. Unused for other Mode values.
+	DebounceMs int `json:"debounceMs,omitempty"`
 }
 
 func (s *Subscribe) key() string {
-	return s.ResourceType + "/" + s.Namespace + "/" + s.ID + "/" + s.Selector + "/" + string(s.Mode)
+	return s.ResourceType + "/" + s.Namespace + "/" + s.ID + "/" + s.Selector + "/" + string(s.Mode) + "/" + strconv.Itoa(s.DebounceMs)
 }
 
 func NewHandler(getter SchemasGetter, serverVersion string) types.RequestListHandler {


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/40773

Depends on https://github.com/rancher/apiserver/pull/160 and https://github.com/rancher/apiserver/pull/161

When in notification mode, the UI is expected to make another LIST request when it is notified that something changed. Since many changes can happen in a short amount of time, the UI want a mechanism to debounce those notifications so it doesn't make a LOT of LIST request.

The debouncer works like this:
- On error event, send the error event to the consumer (which will send an error to the UI)
- On first notification, send a notification right away. There is no need to wait in this case.
- On other notifications, start a timer and only send a notification after that timer is done.

We make the debounce rate configurable by the UI in case they want different rate for different types of objects.

Here's an example session:

```
# Notification mode with debounce rate of 2000
{"resourceType":"configmaps","mode":"resource.changes","debounceMs":2000}
{"name":"resource.start","resourceType":"configmaps","mode":"resource.changes","data":{"type":"subscribe","links":{}}}

# Notification right away
{"name":"resource.changes","resourceType":"configmaps","mode":"resource.changes","data":{"type":"subscribe","links":{}}}

# Notification 2 seconds later
{"name":"resource.changes","resourceType":"configmaps","mode":"resource.changes","data":{"type":"subscribe","links":{}}}
```