### PR TITLE
Give some chance to consumers

### DIFF
--- a/pkg/subscribe/watcher.go
+++ b/pkg/subscribe/watcher.go
@@ -119,7 +119,9 @@ func (s *WatchSession) stream(ctx context.Context, sub Subscribe, result chan<- 
 
 			select {
 			case result <- event:
-			default:
+			// Give enough time for consumer to handle events, for
+			// example when many objects are in the c channel
+			case <-time.After(10 * time.Millisecond):
 				// handle slow consumer
 				go func() {
 					for range c {


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/40773

Having many events come quickly into the c channel can cause the watch to be canceled even though the consumer is NOT slow.

To fix this, we give some maximum time for an event to arrive in the queue, giving a chance to the consumer to consume the event and get ready again.

The current buffered channel has a [capacity of 100 events](https://github.com/rancher/apiserver/blob/d9fba374263d2297c4ca9786f048e600a781bd67/pkg/subscribe/watcher.go#L151), after 100 events it blocks and then the consumer is considered too slow event that's not the case.