### PR TITLE
Remove gorilla/mux as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,14 +153,15 @@ s.Schemas.MustAddSchema(types.APISchema{
 
 Routes need to be defined in order for requests to be routed to the correct
 schema. The parser assumes that some or all of these variables may be defined
-in the as part of a [gorilla/mux](https://pkg.go.dev/github.com/gorilla/mux)
-router: "type", "name", "namespace", "link", "prefix", "action". It uses these
+as part of the http.ServeMux router: "type", "name", "namespace", "link", "prefix", "action". It uses these
 assumptions to decode the `http.Request` into an `APIRequest`. For example,
 for a route like:
 
 ```go
-import "github.com/gorilla/mux"
-router := mux.NewRouter()
+import "net/http"
+
+// Path variables with http.ServeMux require Go 1.22+
+router := http.NewServeMux()
 router.Handle("/{prefix}/{type}/{namespace}/{name}", s)
 ```
 

--- a/example.go
+++ b/example.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/rancher/apiserver/pkg/server"
 	"github.com/rancher/apiserver/pkg/store/apiroot"
 	"github.com/rancher/apiserver/pkg/store/empty"
@@ -57,13 +56,14 @@ func main() {
 	// Register root handler to list api versions
 	apiroot.Register(s.Schemas, []string{"v1", "v2"})
 
-	// Setup mux router to assign variables the server will look for (refer to MuxURLParser for all variable names)
-	router := mux.NewRouter()
+	// Setup http router to assign variables the server will look for (refer to MuxURLParser for all variable names).
+	// This requires Go 1.22+ for path variable support in the standard library's ServeMux.
+	router := http.NewServeMux()
 	router.Handle("/{prefix}/{type}", s)
 	router.Handle("/{prefix}/{type}/{name}", s)
 
-	// When a route is found construct a custom API request to serves up the API root content
-	router.NotFoundHandler = http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	// Fallback to API root content for any other path.
+	router.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
 		s.Handle(&types.APIRequest{
 			Request:   r,
 			Response:  rw,

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ toolchain go1.24.2
 require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/mock v1.6.0
-	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/prometheus/client_golang v1.22.0
 	github.com/rancher/wrangler/v3 v3.2.2-rc.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/pkg/middleware/cache.go
+++ b/pkg/middleware/cache.go
@@ -3,11 +3,9 @@ package middleware
 import (
 	"net/http"
 	"strings"
-
-	"github.com/gorilla/mux"
 )
 
-func CacheMiddleware(suffixes ...string) mux.MiddlewareFunc {
+func CacheMiddleware(suffixes ...string) MiddlewareFunc {
 	return func(handler http.Handler) http.Handler {
 		return Cache(handler, suffixes...)
 	}

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -2,11 +2,12 @@ package middleware
 
 import (
 	"net/http"
-
-	"github.com/gorilla/mux"
 )
 
-type Chain []mux.MiddlewareFunc
+// MiddlewareFunc is a function that wraps an http.Handler.
+type MiddlewareFunc func(http.Handler) http.Handler
+
+type Chain []MiddlewareFunc
 
 func (m Chain) Handler(handler http.Handler) http.Handler {
 	rtn := handler

--- a/pkg/parse/browser.go
+++ b/pkg/parse/browser.go
@@ -3,8 +3,6 @@ package parse
 import (
 	"net/http"
 	"strings"
-
-	"github.com/gorilla/mux"
 )
 
 func IsBrowser(req *http.Request, checkAccepts bool) bool {
@@ -19,10 +17,10 @@ func IsBrowser(req *http.Request, checkAccepts bool) bool {
 	return strings.Contains(userAgent, "mozilla") && strings.Contains(accepts, "*/*")
 }
 
-func MatchNotBrowser(req *http.Request, match *mux.RouteMatch) bool {
-	return !MatchBrowser(req, match)
+func MatchNotBrowser(req *http.Request) bool {
+	return !MatchBrowser(req)
 }
 
-func MatchBrowser(req *http.Request, _ *mux.RouteMatch) bool {
+func MatchBrowser(req *http.Request) bool {
 	return IsBrowser(req, true)
 }

--- a/pkg/parse/mux.go
+++ b/pkg/parse/mux.go
@@ -3,56 +3,21 @@ package parse
 import (
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/rancher/apiserver/pkg/types"
 )
 
-type Vars struct {
-	Type      string
-	Name      string
-	Namespace string
-	Link      string
-	Prefix    string
-	Action    string
-}
-
-func Set(v Vars) mux.MatcherFunc {
-	return func(request *http.Request, match *mux.RouteMatch) bool {
-		if match.Vars == nil {
-			match.Vars = map[string]string{}
-		}
-		if v.Type != "" {
-			match.Vars["type"] = v.Type
-		}
-		if v.Name != "" {
-			match.Vars["name"] = v.Name
-		}
-		if v.Link != "" {
-			match.Vars["link"] = v.Link
-		}
-		if v.Prefix != "" {
-			match.Vars["prefix"] = v.Prefix
-		}
-		if v.Action != "" {
-			match.Vars["action"] = v.Action
-		}
-		if v.Namespace != "" {
-			match.Vars["namespace"] = v.Namespace
-		}
-		return true
-	}
-}
-
+// MuxURLParser is a URL parser that uses path variables from `net/http` routing.
+// This requires Go 1.22+ for path variable support in the standard library.
+// It is named MuxURLParser for backward compatibility, but no longer uses gorilla/mux.
 func MuxURLParser(rw http.ResponseWriter, req *http.Request, schemas *types.APISchemas) (ParsedURL, error) {
-	vars := mux.Vars(req)
 	url := ParsedURL{
-		Type:      vars["type"],
-		Name:      vars["name"],
-		Namespace: vars["namespace"],
-		Link:      vars["link"],
-		Prefix:    vars["prefix"],
+		Type:      req.PathValue("type"),
+		Name:      req.PathValue("name"),
+		Namespace: req.PathValue("namespace"),
+		Link:      req.PathValue("link"),
+		Prefix:    req.PathValue("prefix"),
 		Method:    req.Method,
-		Action:    vars["action"],
+		Action:    req.PathValue("action"),
 		Query:     req.URL.Query(),
 	}
 


### PR DESCRIPTION
The [gorilla/mux library](https://github.com/gorilla/mux) has been archived and hasn't been updated in a few years. In apiserver we use it for routing, but in Go 1.22 routing enhancements were introduced that cover our use case https://go.dev/blog/routing-enhancements.

This PR replaces all instances of `gorilla/mux` with the standard library `net/http`.