### PR TITLE
Update to use golangci-lint v2.1.0. 

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,8 +21,8 @@ jobs:
         go-version-file: 'go.mod'
 
     - name: Install golangci-lint
-      uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
       with:
-        version: v1.64.8
+        version: v2.1.0
 
     - run: make test

--- a/pkg/middleware/content.go
+++ b/pkg/middleware/content.go
@@ -38,5 +38,5 @@ func (c ContentTypeWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if hijacker, ok := c.ResponseWriter.(http.Hijacker); ok {
 		return hijacker.Hijack()
 	}
-	return nil, nil, fmt.Errorf("Upstream ResponseWriter of type %v does not implement http.Hijacker", reflect.TypeOf(c.ResponseWriter))
+	return nil, nil, fmt.Errorf("upstream ResponseWriter of type %v does not implement http.Hijacker", reflect.TypeOf(c.ResponseWriter))
 }

--- a/pkg/middleware/gzip.go
+++ b/pkg/middleware/gzip.go
@@ -27,7 +27,7 @@ func (g gzipResponseWriter) Write(b []byte) (int, error) {
 // Close uses gzip to write gzip footer if message is gzip encoded
 func (g gzipResponseWriter) Close(writer *gzip.Writer) {
 	if g.Header().Get("Content-Encoding") == "gzip" {
-		writer.Close()
+		_ = writer.Close()
 	}
 }
 
@@ -60,5 +60,5 @@ func (g *gzipResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if hijacker, ok := g.ResponseWriter.(http.Hijacker); ok {
 		return hijacker.Hijack()
 	}
-	return nil, nil, fmt.Errorf("Upstream ResponseWriter of type %v does not implement http.Hijacker", reflect.TypeOf(g.ResponseWriter))
+	return nil, nil, fmt.Errorf("upstream ResponseWriter of type %v does not implement http.Hijacker", reflect.TypeOf(g.ResponseWriter))
 }

--- a/pkg/store/schema/schema_store.go
+++ b/pkg/store/schema/schema_store.go
@@ -18,7 +18,7 @@ func NewSchemaStore() types.Store {
 
 func toAPIObject(schema *types.APISchema) types.APIObject {
 	s := schema.DeepCopy()
-	delete(s.Schema.Attributes, "access")
+	delete(s.Attributes, "access")
 	return types.APIObject{
 		Type:   "schema",
 		ID:     schema.ID,

--- a/pkg/subscribe/handler.go
+++ b/pkg/subscribe/handler.go
@@ -63,7 +63,9 @@ func handler(apiOp *types.APIRequest, getter SchemasGetter, serverVersion string
 	if err != nil {
 		return err
 	}
-	defer c.Close()
+	defer func() {
+		_ = c.Close()
+	}()
 
 	watches := NewWatchSession(apiOp, getter)
 	defer watches.Close()
@@ -114,7 +116,9 @@ func writeData(apiOp *types.APIRequest, getter SchemasGetter, c *websocket.Conn,
 	if err != nil {
 		return err
 	}
-	defer messageWriter.Close()
+	defer func() {
+		_ = messageWriter.Close()
+	}()
 
 	return json.NewEncoder(messageWriter).Encode(event)
 }

--- a/pkg/urlbuilder/redirect.go
+++ b/pkg/urlbuilder/redirect.go
@@ -22,7 +22,7 @@ func RedirectRewrite(next http.Handler) http.Handler {
 			r.Hijacker = h
 		}
 		next.ServeHTTP(r, req)
-		r.Close()
+		_ = r.Close()
 	})
 }
 
@@ -46,7 +46,7 @@ func (r *redirector) Close() error {
 		return nil
 	}
 
-	content := bytes.Replace(r.tempBuffer.Bytes(), []byte(r.from), []byte(r.to), -1)
+	content := bytes.ReplaceAll(r.tempBuffer.Bytes(), []byte(r.from), []byte(r.to))
 	_, err := r.ResponseWriter.Write(content)
 	r.tempBuffer = nil
 	return err

--- a/pkg/writer/gzip.go
+++ b/pkg/writer/gzip.go
@@ -31,13 +31,17 @@ func setup(apiOp *types.APIRequest) (*types.APIRequest, io.Closer) {
 
 func (g *GzipWriter) Write(apiOp *types.APIRequest, code int, obj types.APIObject) {
 	apiOp, closer := setup(apiOp)
-	defer closer.Close()
+	defer func() {
+		_ = closer.Close()
+	}()
 	g.ResponseWriter.Write(apiOp, code, obj)
 }
 
 func (g *GzipWriter) WriteList(apiOp *types.APIRequest, code int, obj types.APIObjectList) {
 	apiOp, closer := setup(apiOp)
-	defer closer.Close()
+	defer func() {
+		_ = closer.Close()
+	}()
 	g.ResponseWriter.WriteList(apiOp, code, obj)
 }
 


### PR DESCRIPTION
Issue:  https://github.com/rancher/rancher/issues/51384
Update to use golangci-lint v2.1.0. 
Also a few tweaks to satisfy the new linting rules.