### PR TITLE
Intentionally ignoring error from ParseMultipartForm

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -165,10 +165,8 @@ func parseMethod(req *http.Request) string {
 }
 
 func Body(req *http.Request) (types.APIObject, error) {
-	err := req.ParseMultipartForm(maxFormSize)
-	if err != nil {
-		return types.APIObject{}, err
-	}
+	_ = req.ParseMultipartForm(maxFormSize)
+
 	if req.MultipartForm != nil {
 		return valuesToBody(req.MultipartForm.Value), nil
 	}


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/44817

Intentionally ignoring error from ParseMultipartForm.  This behavior changed when we adapted for linting, but we actually want to ignore in this case.