### PR TITLE
Remove hardcoded releases.rancher.com from ui file paths

### DIFF
--- a/pkg/writer/html.go
+++ b/pkg/writer/html.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	JSURL          = "https://releases.rancher.com/api-ui/%API_UI_VERSION%/ui.min.js"
-	CSSURL         = "https://releases.rancher.com/api-ui/%API_UI_VERSION%/ui.min.css"
+	JSURL          = "/api-ui/%API_UI_VERSION%/ui.min.js"
+	CSSURL         = "/api-ui/%API_UI_VERSION%/ui.min.css"
 	DefaultVersion = "1.1.11"
 )
 


### PR DESCRIPTION
SURE Issue: https://jira.suse.com/browse/SURE-10670

### Summary

- The releases.rancher.com is hardcoded and so the UI will always fetch from releases.rancher.com even in airgapped environment. 
- Instead of this, we should rely on routing of rancher in this PR <rancher pr link> which will intelligently consider settings flag ui-offline-preferred and fetch acocording either from local directory or releases.rancher.com.