### PR TITLE
[release/v0.7] Split release workflow into Cut release and On release

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,8 +299,8 @@ See [VERSION.md](VERSION.md).
 # Releasing
 
 Releases are cut by triggering the [Cut release workflow](.github/workflows/cut-release.yaml)
-from the GitHub Actions tab. Select the appropriate release branch (e.g. `release/v0.5`)
-and provide the version (e.g. `v0.5.1`) as input. The workflow validates the version
-against [VERSION.md](VERSION.md), creates the annotated tag, and dispatches the
-[On release workflow](.github/workflows/release.yaml) on the new tag, which creates
-the GitHub release.
+from the GitHub Actions tab. Select this release branch and provide the version
+(e.g. `v0.7.1`) as input. The workflow validates the version against
+[VERSION.md](VERSION.md) on the default branch, creates the annotated tag, and
+dispatches the [On release workflow](.github/workflows/release.yaml) on the new
+tag, which creates the GitHub release.


### PR DESCRIPTION
# Issue rancher/rancher#54790

Backport of the workflow split (rancher/apiserver#258) to release/v0.7.

## Summary

Replaces the `on: push: tags: v*` trigger with two `workflow_dispatch` workflows that validate the version before creating the tag and GitHub release.

- **`.github/workflows/cut-release.yaml`** ("Cut release") — entry point. Validates the version against `VERSION.md` (read from the default branch), creates and pushes the annotated tag, then dispatches the On release workflow at the new tag ref.
- **`.github/workflows/release.yaml`** ("On release") — `workflow_dispatch`. A `guard` job rejects any dispatch on a non-tag ref. The `release` job creates the GitHub release using `github.ref_name` as the version.

## Why two workflows

A `push: tags` trigger does not work here: GitHub blocks workflow runs triggered by `GITHUB_TOKEN` from starting other runs via push events, so the tag pushed by Cut release would not fire On release. `workflow_dispatch` is exempt from that restriction.