### PR TITLE
[release/v0.5] Split release workflow into Cut release and On release

### DIFF
--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -1,0 +1,118 @@
+name: Cut release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. v0.5.1)'
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Version '$VERSION' must match v<major>.<minor>.<patch>[-prerelease]"
+            exit 1
+          fi
+
+      - name: Resolve allowed minor from VERSION.md
+        id: minor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          table=$(gh api "repos/$GITHUB_REPOSITORY/contents/VERSION.md" --jq .content | base64 -d)
+          allowed=$(grep -F "| $GITHUB_REF_NAME |" <<< "$table" | cut -d'|' -f3 | tr -d ' ')
+          if [ -z "$allowed" ]; then
+            echo "::error::Branch '$GITHUB_REF_NAME' not found in default-branch VERSION.md"
+            exit 1
+          fi
+          echo "Branch '$GITHUB_REF_NAME' is allowed minor '$allowed'"
+          echo "allowed=$allowed" >> "$GITHUB_OUTPUT"
+
+      - name: Validate version matches branch's allowed minor
+        env:
+          VERSION: ${{ inputs.version }}
+          ALLOWED: ${{ steps.minor.outputs.allowed }}
+        run: |
+          if [[ "$VERSION" != "${ALLOWED}."* ]]; then
+            echo "::error::Version $VERSION does not belong to branch $GITHUB_REF_NAME (allowed minor: $ALLOWED)"
+            exit 1
+          fi
+
+      - name: Validate version is next-sequential
+        env:
+          VERSION: ${{ inputs.version }}
+          ALLOWED: ${{ steps.minor.outputs.allowed }}
+        run: |
+          v_core="${VERSION%%-*}"
+          latest=$(git tag -l "${ALLOWED}.*" | grep -v -- '-' | sort --version-sort | tail -n1 || true)
+          if [ -z "$latest" ]; then
+            if [ "$v_core" != "${ALLOWED}.0" ]; then
+              echo "::error::No prior ${ALLOWED} tags; first version must be ${ALLOWED}.0 (got $v_core)"
+              exit 1
+            fi
+            echo "First release on ${ALLOWED} line: OK"
+          else
+            patch="${latest##*.}"
+            expected="${ALLOWED}.$((patch + 1))"
+            if [ "$v_core" != "$expected" ]; then
+              echo "::error::Latest ${ALLOWED} tag is $latest; next must be $expected (got $v_core)"
+              exit 1
+            fi
+            echo "Next sequential after $latest: OK"
+          fi
+
+      - name: Validate tag does not already exist
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag '$VERSION' already exists"
+            exit 1
+          fi
+
+  tag:
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Configure git identity
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Create and push tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
+
+      - name: Trigger On release workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh workflow run release.yaml --repo "$GITHUB_REPOSITORY" --ref "$VERSION"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,22 +1,34 @@
-name: Release
+name: On release
 
 on:
-  push:
-    tags:
-      - v*
+  workflow_dispatch:
+
+permissions: {}
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure ref is a tag
+        run: |
+          if [ "$GITHUB_REF_TYPE" != "tag" ]; then
+            echo "::error::This workflow must be dispatched on a tag ref (got ${GITHUB_REF_TYPE} '${GITHUB_REF}')"
+            exit 1
+          fi
+
   release:
+    needs: guard
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-    - name : Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Create release on Github
-      run: |
-        gh --repo "${{ github.repository }}" release create ${{ github.ref_name }} --verify-tag --generate-notes
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          gh --repo "$GITHUB_REPOSITORY" release create "$VERSION" \
+            --verify-tag --generate-notes

--- a/README.md
+++ b/README.md
@@ -304,3 +304,12 @@ s.AccessControl = &accessControl{}
 # Versioning
 
 See [VERSION.md](VERSION.md).
+
+# Releasing
+
+Releases are cut by triggering the [Cut release workflow](.github/workflows/cut-release.yaml)
+from the GitHub Actions tab. Select this release branch and provide the version
+(e.g. `v0.5.1`) as input. The workflow validates the version against
+[VERSION.md](VERSION.md) on the default branch, creates the annotated tag, and
+dispatches the [On release workflow](.github/workflows/release.yaml) on the new
+tag, which creates the GitHub release.


### PR DESCRIPTION
# Issue rancher/rancher#54790

Backport of the workflow split (rancher/apiserver#258) to release/v0.5.

## Summary

Replaces the `on: push: tags: v*` trigger with two `workflow_dispatch` workflows that validate the version before creating the tag and GitHub release.

- **`.github/workflows/cut-release.yaml`** ("Cut release") — entry point. Validates the version against `VERSION.md` (read from the default branch), creates and pushes the annotated tag, then dispatches the On release workflow at the new tag ref.
- **`.github/workflows/release.yaml`** ("On release") — `workflow_dispatch`. A `guard` job rejects any dispatch on a non-tag ref. The `release` job creates the GitHub release using `github.ref_name` as the version.

## Why two workflows

A `push: tags` trigger does not work here: GitHub blocks workflow runs triggered by `GITHUB_TOKEN` from starting other runs via push events, so the tag pushed by Cut release would not fire On release. `workflow_dispatch` is exempt from that restriction.