### PR TITLE
Branch out release/v0.9

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
   ],
   "baseBranchPatterns": [
     "main",
+    "release/v0.9",
     "release/v0.8",
     "release/v0.7",
     "release/v0.6",

--- a/VERSION.md
+++ b/VERSION.md
@@ -2,7 +2,8 @@ APIServer follows a pre-release (v0.x) strategy of semver. There is no compatibi
 
 | APIServer Branch | APIServer Minor version | Matching Rancher Version |
 |------------------|-------------------------|--------------------------|
-| main | v0.9 | v2.15 |
+| main | v0.10 | v2.16 |
+| release/v0.9 | v0.9 | v2.15 |
 | release/v0.8 | v0.8 | v2.14 |
 | release/v0.7 | v0.7 | v2.13 |
 | release/v0.6 | v0.6 | v2.12 |


### PR DESCRIPTION
Following rancher/rancher branching for v2.15 (release/v2.15).

- Add `release/v0.9` to renovate `baseBranchPatterns`
- Update `VERSION.md`: `main` now tracks v0.10 (Rancher v2.16); `release/v0.9` tracks v2.15

Part of the frameworks branch-out for the new Rancher minor.