### PR TITLE
[main] Migrate renovate config to per-release-line presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,10 +8,7 @@
     "release/v0.8",
     "release/v0.7",
     "release/v0.6",
-    "release/v0.5",
-    "release/v0.4",
-    "release/v0.3",
-    "release/v0.2"
+    "release/v0.5"
   ],
   "prHourlyLimit": 2,
   "enabledManagers": [
@@ -21,10 +18,32 @@
   ],
   "packageRules": [
     {
+      "matchBaseBranches": ["main"],
+      "extends": ["github>rancher/renovate-config:rancher-main#main"]
+    },
+    {
+      "matchBaseBranches": ["release/v0.9"],
+      "extends": ["github>rancher/renovate-config:rancher-2.15#main"]
+    },
+    {
+      "matchBaseBranches": ["release/v0.8"],
+      "extends": ["github>rancher/renovate-config:rancher-2.14#main"]
+    },
+    {
+      "matchBaseBranches": ["release/v0.7"],
+      "extends": ["github>rancher/renovate-config:rancher-2.13#main"]
+    },
+    {
+      "matchBaseBranches": ["release/v0.6"],
+      "extends": ["github>rancher/renovate-config:rancher-2.12#main"]
+    },
+    {
+      "matchBaseBranches": ["release/v0.5"],
+      "extends": ["github>rancher/renovate-config:rancher-2.11#main"]
+    },
+    {
       "enabled": false,
       "matchPackageNames": [
-        "/k8s.io/*/",
-        "/sigs.k8s.io/*/",
         "/go.opentelemetry.io/*/",
         "/github.com/prometheus/*/",
         "/github.com/rancher/wrangler/*/"
@@ -70,13 +89,6 @@
       ],
       "groupName": "Go dev tools",
       "separateMajorMinor": false
-    },
-    {
-      "description": "Group golang.org/x/* packages into a single PR per branch",
-      "matchPackageNames": [
-        "/^golang\\.org\\/x\\//"
-      ],
-      "groupName": "golang.org/x packages"
     }
   ]
 }

--- a/VERSION.md
+++ b/VERSION.md
@@ -8,8 +8,4 @@ APIServer follows a pre-release (v0.x) strategy of semver. There is no compatibi
 | release/v0.7 | v0.7 | v2.13 |
 | release/v0.6 | v0.6 | v2.12 |
 | release/v0.5 | v0.5 | v2.11 |
-| release/v0.4 | v0.4 | v2.10 |
-| release/v0.3 | v0.3 | v2.9 |
-| release/v0.2 | v0.2 | v2.8 |
-| release/v0.1 | v0.1 | v2.7 |
 


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/50186
Also removing EOL versions from VERSION.md